### PR TITLE
ci: Build the CI image

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,5 +1,5 @@
 env:
-  IMAGE_TAG: 2025.03.26-6
+  IMAGE_TAG: 2025.08.12-0
 
 on:
   workflow_call:


### PR DESCRIPTION
There currently is no build image in the flatpak org, so let's build one!

In the future this should happen automatically because merge queues are turned on and the CI actor isn't me anymore when merging.